### PR TITLE
missing profile scope from inline form config breaks the return page

### DIFF
--- a/src/Plugin/views/field/CommerceReturnEditQuantity.php
+++ b/src/Plugin/views/field/CommerceReturnEditQuantity.php
@@ -196,6 +196,7 @@ class CommerceReturnEditQuantity extends FieldPluginBase {
     /** @var \Drupal\profile\Entity\ProfileInterface $billing_profile */
     $billing_profile = $order->getBillingProfile()->createDuplicate();
     $billing_inline_form = $this->inlineFormManager->createInstance('customer_profile', [
+      'profile_scope' => 'billing',
       'available_countries' => $order->getStore()->getBillingCountries(),
     ], $billing_profile);
 
@@ -224,6 +225,7 @@ class CommerceReturnEditQuantity extends FieldPluginBase {
 
       $shipping_inline_form = $this->inlineFormManager->createInstance('customer_profile', [
         'available_countries' => $order->getStore()->getBillingCountries(),
+        'profile_scope' => 'shipping',
       ], $shipping_profile);
 
       $form['actions']['another_location_shipping'] = [


### PR DESCRIPTION
Missing profile scope from inline form config breaks the return page with this error. 

`RuntimeException:` The "customer_profile" plugin requires the "profile_scope" configuration key in Drupal\commerce\Plugin\Commerce\InlineForm\InlineFormBase->validateConfiguration() (line 89 of /Users/qed42/sites/Newshop/shopthearea-drupal/web/modules/contrib/commerce/src/Plugin/Commerce/InlineForm/InlineFormBase.php).`

This pull request will fix this issue. 